### PR TITLE
Cart button names

### DIFF
--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -6,11 +6,11 @@
   <h3>Name: <%= freelancer.name %></h3>
   <p><%= freelancer.description %></p>
   <p>Quantity: <%= @cart.count_of(freelancer.id)%></p>
-  <%= button_to "Add another hour", cart_index_path(freelancer_id: freelancer.id), class: "btn btn-danger"%>
-  <%= button_to "Remove 1", cart_path(freelancer_id: freelancer.id), class: "btn btn-danger", method: :patch%>
+  <%= button_to "Add an hour", cart_index_path(freelancer_id: freelancer.id), class: "btn btn-danger"%>
+  <%= button_to "Remove an hour", cart_path(freelancer_id: freelancer.id), class: "btn btn-danger", method: :patch%>
   <p>$<%= freelancer.price %>/hr</p>
   <p> Subtotal: $<%= @cart.subtotal(freelancer) %></p>
-  <%= link_to "Remove", cart_index_path(freelancer_id: freelancer.id), method: :delete %>
+  <%= link_to "Remove #{freelancer.name}'s time from your cart.", cart_index_path(freelancer_id: freelancer.id), method: :delete %>
 
 </div>
 <% end %>

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -6,7 +6,7 @@
   <h3>Name: <%= freelancer.name %></h3>
   <p><%= freelancer.description %></p>
   <p>Quantity: <%= @cart.count_of(freelancer.id)%></p>
-  <%= button_to "Add 1", cart_index_path(freelancer_id: freelancer.id), class: "btn btn-danger"%>
+  <%= button_to "Add another hour", cart_index_path(freelancer_id: freelancer.id), class: "btn btn-danger"%>
   <%= button_to "Remove 1", cart_path(freelancer_id: freelancer.id), class: "btn btn-danger", method: :patch%>
   <p>$<%= freelancer.price %>/hr</p>
   <p> Subtotal: $<%= @cart.subtotal(freelancer) %></p>

--- a/spec/features/cart/visitor_can_adjust_quantities_spec.rb
+++ b/spec/features/cart/visitor_can_adjust_quantities_spec.rb
@@ -15,7 +15,7 @@ describe "As a visitor" do
       expect(page).to have_content("Subtotal: $100")
       expect(page).to have_content("Total: $100")
 
-      click_button "Add another hour"
+      click_button "Add an hour"
 
       expect(current_path).to eq("/cart")
       expect(page).to have_content("Quantity: 2")
@@ -25,12 +25,12 @@ describe "As a visitor" do
     end
 
     scenario "I can decrease the quantity of an item" do
-      click_button "Add another hour"
+      click_button "Add an hour"
       expect(page).to have_content("Quantity: 2")
       expect(page).to have_content("Subtotal: $200")
       expect(page).to have_content("Total: $200")
 
-      click_button "Remove 1"
+      click_button "Remove an hour"
 
 
       expect(page).to have_content("Quantity: 1")

--- a/spec/features/cart/visitor_can_adjust_quantities_spec.rb
+++ b/spec/features/cart/visitor_can_adjust_quantities_spec.rb
@@ -15,7 +15,7 @@ describe "As a visitor" do
       expect(page).to have_content("Subtotal: $100")
       expect(page).to have_content("Total: $100")
 
-      click_button "Add 1"
+      click_button "Add another hour"
 
       expect(current_path).to eq("/cart")
       expect(page).to have_content("Quantity: 2")
@@ -25,13 +25,13 @@ describe "As a visitor" do
     end
 
     scenario "I can decrease the quantity of an item" do
-      click_button "Add 1"
+      click_button "Add another hour"
       expect(page).to have_content("Quantity: 2")
       expect(page).to have_content("Subtotal: $200")
       expect(page).to have_content("Total: $200")
 
       click_button "Remove 1"
-      
+
 
       expect(page).to have_content("Quantity: 1")
       expect(page).to have_content("Subtotal: $100")

--- a/spec/features/cart/visitor_can_remove_an_item_from_cart_spec.rb
+++ b/spec/features/cart/visitor_can_remove_an_item_from_cart_spec.rb
@@ -12,7 +12,7 @@ describe "As a visitor" do
 
       expect(page).to have_content(freelancer.name)
 
-      click_link "Remove"
+      click_link "Remove #{freelancer.name}'s time from your cart."
 
 
       expect(current_path).to eq(cart_path)
@@ -31,7 +31,7 @@ describe "As a visitor" do
 
       visit cart_path
 
-      click_link "Remove"
+      click_link "Remove #{freelancer.name}'s time from your cart."
 
       within(".remove") do
         click_link  "#{freelancer.name}"


### PR DESCRIPTION
#### What's this PR do?
Changes the button and link names on the cart page.
To change the quantity of time, the buttons say ```Add an hour``` and ```Remove an hour```

To remove the freelancer from the entire cart, it now says ```Remove <freelancer.name>'s time from your cart.```

#### Where should the reviewer start- what are the pertinent changes and the sequence?
Cart show page and then the tests visitor_can_adjust...rb & visitor_can_remove...rb

#### How should this be manually tested?
Add a freelancer to a cart and then view the cart page. The buttons should have the correct labeling now.

#### Any background context you want to provide?
Eventually we'd want a red X button in the item area to delete it from the cart. Right now, the link will suffice.
<img width="466" alt="screen shot 2017-11-02 at 2 54 29 pm" src="https://user-images.githubusercontent.com/24700836/32349776-cdb4fa56-bfdd-11e7-92c6-fc41999de5b1.png">

#### What are the relevant tickets?
Close #37 
#### Screenshots (if appropriate)

#### Questions:
